### PR TITLE
BREAKING CHANGE: Updates yolo prediction tensor to make it compliant …

### DIFF
--- a/vsdkx/model/yolo_torch/driver.py
+++ b/vsdkx/model/yolo_torch/driver.py
@@ -41,7 +41,7 @@ class YoloTorchDriver(ModelDriver):
 
         inf_start = time.perf_counter()
         # Run the inference
-        x = self._yolo(resized_image)[0]
+        x = self._yolo(resized_image)
 
         # Run the NMS to get the boxes with the highest confidence
         y = self._process_pred(x)


### PR DESCRIPTION
## Description 

This MR introduces the following changes: 
- Reverts model weights to training_2_best.pt 
- Fixes prediction return to solve breaking change incompatibility with yolov5 tag v.6 

## How to test

Open two terminal tabs one for visionx and one for people detection:

- Set `visionx` to run on people detection and run `make` 
- Run `make build` and as soon as it's completed run `make run` on the people detection tab

## What to expect

The people detection repo detects people as expected, and everything runs in synergy with `visionx`.