### PR TITLE
Update: driver.py supports pretrained yolo model

### DIFF
--- a/vsdkx/model/yolo_torch/driver.py
+++ b/vsdkx/model/yolo_torch/driver.py
@@ -22,7 +22,8 @@ class YoloTorchDriver(ModelDriver):
         self._iou_thresh = model_settings['iou_thresh']
         self._device = model_settings['device']
         self._model_name = model_config.get('model_name', 'custom')
-        self._model_path = {'path': model_config.get('model_path', None)}
+        self._model_path = {} if model_config.get('model_path') is None \
+            else {'path': model_config.get('model_path')}
         self._yolo = torch.hub.load('ultralytics/yolov5',
                                     self._model_name,
                                     **self._model_path)

--- a/vsdkx/model/yolo_torch/driver.py
+++ b/vsdkx/model/yolo_torch/driver.py
@@ -21,8 +21,11 @@ class YoloTorchDriver(ModelDriver):
         self._conf_thresh = model_settings['conf_thresh']
         self._iou_thresh = model_settings['iou_thresh']
         self._device = model_settings['device']
-        self._yolo = torch.hub.load('ultralytics/yolov5', 'custom',
-                                    path=model_config['model_path'])
+        self._model_name = model_config.get('model_name', 'custom')
+        self._model_path = {'path': model_config.get('model_path', None)}
+        self._yolo = torch.hub.load('ultralytics/yolov5',
+                                    self._model_name,
+                                    **self._model_path)
 
     def inference(self, frame_object: FrameObject) -> Inference:
         """


### PR DESCRIPTION
## Description 

This MR updates the `driver.py` to allow passing arguments in `torch.hub.load` and support the loading of pretrained and custom models. 

## How to test

1. Initiate visionx to run using the people detection and [dog detection] (https://gitlab.com/natix/cvison/product/dogdetector/-/merge_requests/1) ai processors 
2. Update the `requirements.txt` on both ai processors to install `yolo-torch` on this branch 
3. `make run` on each ai processor

## What to expect

Both ai processors should run without any errors, triggering yolo-torch to run in two different models in parallel. Streams are successfully inferences and both people and dogs are detected.  