### PR TITLE
perf: add unit test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,41 @@
+name: Semantic Release and Upload Python Package
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [created]    
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    concurrency: release
+  
+    steps:
+     - uses: actions/checkout@main
+     - uses: go-semantic-release/action@v1
+       with:
+         changelog-file: CHANGELOG.md
+         github-token: ${{ secrets.TOKEN }}
+  
+  deploy:
+    name: Upload Python Package
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USER }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}  
+      run: |
+        echo ${{ secrets.PYPI_TOKEN }} 
+        python setup.py sdist bdist_wheel
+        twine upload dist/*  
+    

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,9 +1,13 @@
 import unittest
+import numpy as np
+from numpy.core.fromnumeric import shape
 
+from vsdkx.core.structs import FrameObject, Inference
 from vsdkx.model.yolo_torch.driver import YoloTorchDriver
 
 
 class TestDriver(unittest.TestCase):
+    MODEL_DRIVER = None
     
     def test_driver_construction(self):
         
@@ -19,6 +23,24 @@ class TestDriver(unittest.TestCase):
             "device": "cpu"
         }
         
-        model_driver = YoloTorchDriver(model_settings, model_config, drawing_config={})
+        TestDriver.MODEL_DRIVER = YoloTorchDriver(model_settings, model_config, drawing_config={})
         
-        self.assertIsInstance(model_driver, YoloTorchDriver)
+        self.assertIsInstance(TestDriver.MODEL_DRIVER, YoloTorchDriver)
+
+    def test_driver_inference(self):
+        shape =  TestDriver.MODEL_DRIVER._input_shape       
+        shape = shape + (3,)
+
+        frame = np.zeros(shape)
+        frame_object = FrameObject(frame, {})
+
+        inference = TestDriver.MODEL_DRIVER.inference(frame_object)
+        
+        self.assertIsInstance(inference, Inference)
+
+        self.assertEqual(len(inference.boxes), 0)
+        self.assertEqual(len(inference.classes), 0)
+        self.assertEqual(len(inference.scores), 0)
+
+        self.assertEqual(inference.extra, {})
+

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,0 +1,24 @@
+import unittest
+
+from vsdkx.model.yolo_torch.driver import YoloTorchDriver
+
+
+class TestDriver(unittest.TestCase):
+    
+    def test_driver_construction(self):
+        
+        model_config = {
+            "input_shape": (640, 640),
+            "filter_class_ids": [16],
+            "classes_len": 1,
+            "model_name": "yolov5m",
+        }
+        model_settings = {
+            "conf_thresh": 0.5,
+            "iou_thresh": 0.7,
+            "device": "cpu"
+        }
+        
+        model_driver = YoloTorchDriver(model_settings, model_config, drawing_config={})
+        
+        self.assertIsInstance(model_driver, YoloTorchDriver)


### PR DESCRIPTION
Adds unit test to test model driver construction and inference method

to run unit tests, run following command from the top directory

```sh
pip install .
python -m unittest discover tests
```